### PR TITLE
Add FilterPolicy to the supported SNS attributes

### DIFF
--- a/lib/ex_aws/sns.ex
+++ b/lib/ex_aws/sns.ex
@@ -180,7 +180,7 @@ defmodule ExAws.SNS do
   ## Subscriptions
   ######################
 
-  @type subscription_attribute_name :: :delivery_policy | :raw_message_delivery
+  @type subscription_attribute_name :: :delivery_policy | :filter_policy | :raw_message_delivery
 
   @doc "Create Subscription"
   @spec subscribe(topic_arn :: binary, protocol :: binary, endpoint :: binary) :: ExAws.Operation.Query.t

--- a/lib/ex_aws/sns/parsers.ex
+++ b/lib/ex_aws/sns/parsers.ex
@@ -188,6 +188,7 @@ if Code.ensure_loaded?(SweetXml) do
         confirmation_was_authenticated: ~x"./GetSubscriptionAttributesResult/Attributes/entry[./key = 'ConfirmationWasAuthenticated']/value/text()"s,
         delivery_policy: ~x"./GetSubscriptionAttributesResult/Attributes/entry[./key = 'DeliveryPolicy']/value/text()"s,
         effective_delivery_policy: ~x"./GetSubscriptionAttributesResult/Attributes/entry[./key = 'EffectiveDeliveryPolicy']/value/text()"s,
+        filter_policy: ~x"./GetSubscriptionAttributesResult/Attributes/entry[./key = 'FilterPolicy']/value/text()"s,
         request_id: request_id_xpath())
 
       parsed_body = Map.put(parsed_body, :confirmation_was_authenticated, parsed_body[:confirmation_was_authenticated] == "true")

--- a/test/lib/sns/parser_test.exs
+++ b/test/lib/sns/parser_test.exs
@@ -529,6 +529,10 @@ defmodule ExAws.SNS.ParserTest do
               <value>123456789012</value>
             </entry>
             <entry>
+              <key>FilterPolicy</key>
+              <value>{&quot;status&quot;:[&quot;ok&quot;]}</value>
+            </entry>
+            <entry>
               <key>DeliveryPolicy</key>
               <value>{&quot;healthyRetryPolicy&quot;:{&quot;numRetries&quot;:10}}</value>
             </entry>
@@ -557,6 +561,7 @@ defmodule ExAws.SNS.ParserTest do
     assert parsed_doc[:owner] == "123456789012"
     assert parsed_doc[:delivery_policy] == ~s({"healthyRetryPolicy":{"numRetries":10}})
     assert parsed_doc[:effective_delivery_policy] == ~s({"healthyRetryPolicy":{"numRetries":10}})
+    assert parsed_doc[:filter_policy] == ~s({"status":["ok"]})
     assert parsed_doc[:subscription_arn] == "arn:aws:sns:us-east-1:123456789012:My-Topic:80289ba6-0fd4-4079-afb4-ce8c8260f0ca"
     assert parsed_doc[:confirmation_was_authenticated] == true
   end

--- a/test/lib/sns_test.exs
+++ b/test/lib/sns_test.exs
@@ -191,6 +191,17 @@ defmodule ExAws.SNSTest do
       :raw_message_delivery,
       "{\"healthyRetryPolicy\":{\"numRetries\":5}}",
       subscription_arn).params
+
+    expected = %{
+      "Action" => "SetSubscriptionAttributes",
+      "SubscriptionArn" => subscription_arn,
+      "AttributeName" => "FilterPolicy",
+      "AttributeValue" => "{\"status\":[\"ok\"]}",
+    }
+    assert expected == SNS.set_subscription_attributes(
+      :filter_policy,
+      "{\"status\":[\"ok\"]}",
+      subscription_arn).params
   end
 
   test "#list_phone_numbers_opted_out" do


### PR DESCRIPTION
Adds code and tests required to submit and parse the `FilterPolicy` attribute as part of `set_subscription_attributes` and `get_subscription_attributes`.