### PR TITLE
Accept optional ReturnSubscriptionArn on subscribe

### DIFF
--- a/lib/ex_aws/sns.ex
+++ b/lib/ex_aws/sns.ex
@@ -183,13 +183,15 @@ defmodule ExAws.SNS do
   @type subscription_attribute_name :: :delivery_policy | :raw_message_delivery
 
   @doc "Create Subscription"
-  @spec subscribe(topic_arn :: binary, protocol :: binary, endpoint :: binary) :: ExAws.Operation.Query.t
-  def subscribe(topic_arn, protocol, endpoint) do
-    request(:subscribe, %{
+  @spec subscribe(topic_arn :: binary, protocol :: binary, endpoint :: binary, [subscribe_opt]) :: ExAws.Operation.Query.t
+  def subscribe(topic_arn, protocol, endpoint, opts \\ []) do
+    params = Keyword.into(opts, %{
       "TopicArn" => topic_arn,
       "Protocol" => protocol,
       "Endpoint" => endpoint,
     })
+
+    request(:subscribe, opts)
   end
 
   @doc "Confirm Subscription"

--- a/lib/ex_aws/sns.ex
+++ b/lib/ex_aws/sns.ex
@@ -188,11 +188,12 @@ defmodule ExAws.SNS do
   @doc "Create Subscription"
   @spec subscribe(topic_arn :: binary, protocol :: binary, endpoint :: binary, [subscribe_opts]) :: ExAws.Operation.Query.t
   def subscribe(topic_arn, protocol, endpoint, opts \\ []) do
-    params = Enum.into(opts, %{
+    params = %{
       "TopicArn" => topic_arn,
       "Protocol" => protocol,
       "Endpoint" => endpoint,
-    })
+      "ReturnSubscriptionArn" => (opts[:return_subscription_arn] || false),
+    }
 
     request(:subscribe, params)
   end

--- a/lib/ex_aws/sns.ex
+++ b/lib/ex_aws/sns.ex
@@ -181,17 +181,20 @@ defmodule ExAws.SNS do
   ######################
 
   @type subscription_attribute_name :: :delivery_policy | :raw_message_delivery
+  @type subscribe_opts :: [
+    {:return_subscription_arn, boolean}
+  ]
 
   @doc "Create Subscription"
-  @spec subscribe(topic_arn :: binary, protocol :: binary, endpoint :: binary, [subscribe_opt]) :: ExAws.Operation.Query.t
+  @spec subscribe(topic_arn :: binary, protocol :: binary, endpoint :: binary, [subscribe_opts]) :: ExAws.Operation.Query.t
   def subscribe(topic_arn, protocol, endpoint, opts \\ []) do
-    params = Keyword.into(opts, %{
+    params = Enum.into(opts, %{
       "TopicArn" => topic_arn,
       "Protocol" => protocol,
       "Endpoint" => endpoint,
     })
 
-    request(:subscribe, opts)
+    request(:subscribe, params)
   end
 
   @doc "Confirm Subscription"

--- a/test/lib/sns_test.exs
+++ b/test/lib/sns_test.exs
@@ -119,9 +119,23 @@ defmodule ExAws.SNSTest do
       "Action"   => "Subscribe",
       "TopicArn" => "arn:aws:sns:us-east-1:982071696186:test-topic",
       "Protocol" => "https",
-      "Endpoint" => "https://example.com"
+      "Endpoint" => "https://example.com",
+      "ReturnSubscriptionArn" => false
     }
     assert expected == SNS.subscribe("arn:aws:sns:us-east-1:982071696186:test-topic", "https", "https://example.com").params
+  end
+
+  test "#subscribe with return_subscription_arn" do
+    expected = %{
+      "Action"   => "Subscribe",
+      "TopicArn" => "arn:aws:sns:us-east-1:982071696186:test-topic",
+      "Protocol" => "https",
+      "Endpoint" => "https://example.com",
+      "ReturnSubscriptionArn" => true
+    }
+
+    opts = [return_subscription_arn: true]
+    assert expected == SNS.subscribe("arn:aws:sns:us-east-1:982071696186:test-topic", "https", "https://example.com", opts).params
   end
 
   test "#confirm_subscription" do


### PR DESCRIPTION
Passing this optional param will return the ARN of the subscription to you instead of `subscription_arn: "pending confirmation"`

The user will still need to confirm, but you won't have to poll the list of subscriptions later to find the ARN.

Usage: 

```
ExAws.SNS.subscribe(topic_arn, "email", "some@guy.com", [return_subscription_arn: true])
```