### PR TITLE
Remove duplicate subscription_attribute_name introduced in d9e3d3f

### DIFF
--- a/lib/ex_aws/sns.ex
+++ b/lib/ex_aws/sns.ex
@@ -180,10 +180,8 @@ defmodule ExAws.SNS do
   ## Subscriptions
   ######################
 
-  @type subscription_attribute_name :: :delivery_policy | :raw_message_delivery
-  @type subscribe_opt :: {:return_subscription_arn, boolean}
-  
   @type subscription_attribute_name :: :delivery_policy | :filter_policy | :raw_message_delivery
+  @type subscribe_opt :: {:return_subscription_arn, boolean}
 
   @doc "Create Subscription"
   @spec subscribe(topic_arn :: binary, protocol :: binary, endpoint :: binary, [subscribe_opt]) :: ExAws.Operation.Query.t


### PR DESCRIPTION
The double-merge of #10 and #12 resulted in duplicate (and conflicting) typespecs for `subscribtion_attribute_name`. This PR straightens things out. 

cc: @benwilson512 