### PR TITLE
Adding attributes option for create_topic function

### DIFF
--- a/lib/ex_aws/sns.ex
+++ b/lib/ex_aws/sns.ex
@@ -17,6 +17,12 @@ defmodule ExAws.SNS do
     :display_name |
     :delivery_policy
 
+  @type topic_attributes :: [
+    {atom, binary}
+    | {atom, boolean}
+    | {atom, integer}
+  ]
+
   @doc "List topics"
   @spec list_topics() :: ExAws.Operation.Query.t
   @spec list_topics(opts :: [next_token: binary]) :: ExAws.Operation.Query.t
@@ -30,8 +36,14 @@ defmodule ExAws.SNS do
 
   @doc "Create topic"
   @spec create_topic(topic_name :: topic_name) :: ExAws.Operation.Query.t
-  def create_topic(topic_name) do
-    request(:create_topic, %{"Name" => topic_name})
+  @spec create_topic(topic_name :: topic_name, attributes :: topic_attributes) :: ExAws.Operation.Query.t
+  def create_topic(topic_name, attributes \\ []) do
+    params =
+      attributes
+      |> build_attrs()
+      |> Map.put("Name", topic_name)
+
+    request(:create_topic, params)
   end
 
   @doc "Get topic attributes"

--- a/test/lib/sns_test.exs
+++ b/test/lib/sns_test.exs
@@ -7,9 +7,20 @@ defmodule ExAws.SNSTest do
     assert expected == SNS.list_topics().params
   end
 
-  test "#create_topic" do
+  test "create_topic/1" do
     expected = %{"Action" => "CreateTopic", "Name" => "test_topic"}
     assert expected == SNS.create_topic("test_topic").params
+  end
+
+  test "create_topic/2" do
+    expected = %{
+      "Action" => "CreateTopic",
+      "Name" => "test_topic.fifo",
+      "Attributes.entry.1.name" => "FifoTopic",
+      "Attributes.entry.1.value" => true
+    }
+
+    assert expected == SNS.create_topic("test_topic.fifo", [{:fifo_topic, true}]).params
   end
 
   test "#get_topic_attributes" do


### PR DESCRIPTION
Allowing attributes to be filled in topic creation (DeliveryPolicy, FifoTopic, etc).

Eg.:

```
ExAws.SNS.create_topic("test_topic.fifo", [{:fifo_topic, true}])
```

More attributes are described here:
https://docs.aws.amazon.com/cli/latest/reference/sns/create-topic.html#options