### PR TITLE
Updating publish_opts type to support FIFO topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,49 @@ def deps do
 end
 ```
 
+## Usage
+
+### Publishing a message
+
+Here is an example of sending a message to a standard topic and returning the response to the caller
+
+```elixir
+    message
+    |> ExAws.SNS.publish(
+      topic_arn: "arn:aws:sns:us-east-1:000000000000:sns-topic-name"
+    )
+    |> ExAws.request()
+    |> case do
+      {:error, {_error_type, error_code, %{code: message}}} ->
+        {:error, "Response returned with http error code #{error_code} and message #{message}"}
+      {:error, {_error_type, error_code, message}} ->
+        {:error, "Response returned with http error code #{error_code} and message #{message}"}
+      response -> response
+    end
+```
+
+The following code demonstrates sending a message to a FIFO topic. [message_group_id](https://docs.aws.amazon.com/sns/latest/dg/fifo-message-grouping.html) defines partitions in
+the topic to make sure messages in that group are processed one at a time. If all messages must be processed in order
+use a static value for this attribute. [message_deduplication_id](https://docs.aws.amazon.com/sns/latest/dg/fifo-message-dedup.html) defines an id used to determine if two events are the same
+and deduplicate them in the topic. Event IDs or hashes of the content are good for this.
+
+```elixir
+    message
+    |> ExAws.SNS.publish(
+      topic_arn: "arn:aws:sns:us-east-1:000000000000:sns-topic-name.fifo",
+      message_group_id: "some group which requires messages processed in order",
+      message_deduplication_id: "some id to prevent the same message from being published twice"
+    )
+    |> ExAws.request()
+    |> case do
+      {:error, {_error_type, error_code, %{code: message}}} ->
+        {:error, "Response returned with http error code #{error_code} and message #{message}"}
+      {:error, {_error_type, error_code, message}} ->
+        {:error, "Response returned with http error code #{error_code} and message #{message}"}
+      response -> response
+    end
+```
+
 ## Copyright and License
 
 The MIT License (MIT)

--- a/lib/ex_aws/sns.ex
+++ b/lib/ex_aws/sns.ex
@@ -86,6 +86,8 @@ defmodule ExAws.SNS do
           | {:phone_number, binary}
           | {:target_arn, binary}
           | {:topic_arn, binary}
+          | {:message_group_id, binary}
+          | {:message_deduplication_id, binary}
         ]
 
   @doc """

--- a/test/lib/sns_test.exs
+++ b/test/lib/sns_test.exs
@@ -171,6 +171,23 @@ defmodule ExAws.SNSTest do
              ).params
   end
 
+  test "#publish FIFO message" do
+    expected = %{
+      "Action" => "Publish",
+      "Message" => "Hello World",
+      "TopicArn" => "arn:aws:sns:us-east-1:982071696186:test-topic",
+      "MessageDeduplicationId" => "dedupe-id",
+      "MessageGroupId" => "group-id"
+    }
+
+    assert expected ==
+             SNS.publish("Hello World",
+               topic_arn: "arn:aws:sns:us-east-1:982071696186:test-topic",
+               message_group_id: "group-id",
+               message_deduplication_id: "dedupe-id"
+             ).params
+  end
+
   test "#subscribe" do
     expected = %{
       "Action" => "Subscribe",


### PR DESCRIPTION
We were seeing dialyzer errors when attempting to set message_group_id and message_deduplication_id. This fixed it. Also added some docs around publishing because I always look for that and never find it.