### PR TITLE
Fix "String.Array" attribute serialization

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -28,3 +28,6 @@ import Config
 # here (which is why it is important to import them last).
 #
 #     import_config "#{Mix.env}.exs"
+if Mix.env() == :test do
+  import_config "test.exs"
+end

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,4 @@
+import Config
+
+config :ex_aws,
+  json_codec: Poison

--- a/lib/ex_aws/sns.ex
+++ b/lib/ex_aws/sns.ex
@@ -132,6 +132,8 @@ defmodule ExAws.SNS do
     string_array: "String.Array"
   }
 
+  @json_codec Application.fetch_env!(:ex_aws, :json_codec)
+
   def build_message_attribute(
         {%{name: name, data_type: data_type, value: value}, i},
         params
@@ -146,6 +148,10 @@ defmodule ExAws.SNS do
 
   defp put_value(params, param_root, {:binary, value}) do
     params |> Map.put(param_root <> ".Value.BinaryValue", value)
+  end
+
+  defp put_value(params, param_root, {:string_array, value}) do
+    params |> Map.put(param_root <> ".Value.StringValue", @json_codec.encode!(value))
   end
 
   defp put_value(params, param_root, {_, value}) do

--- a/test/lib/sns_test.exs
+++ b/test/lib/sns_test.exs
@@ -178,7 +178,7 @@ defmodule ExAws.SNSTest do
       "TopicArn" => "arn:aws:sns:us-east-1:982071696186:test-topic",
       "MessageAttributes.entry.1.Name" => "SenderIDs",
       "MessageAttributes.entry.1.Value.DataType" => "String.Array",
-      "MessageAttributes.entry.1.Value.StringValue" => ["sender1", "sender2"]
+      "MessageAttributes.entry.1.Value.StringValue" => "[\"sender1\",\"sender2\"]"
     }
 
     attrs = [


### PR DESCRIPTION
Turns out that ExAws assumes that the payload can be URI encoded, so we cannot use JSON-serializable attributes. Pre-serializing arrays should fix the issue.

The error I get is:
> (ArgumentError) encode_query/2 values cannot be lists
>   (elixir 1.12.3) lib/uri.ex:125: URI.encode_kv_pair/2
>   [...]
>   (ex_aws 2.4.0) lib/ex_aws/operation/query.ex:23: ExAws.Operation.ExAws.Operation.Query.perform/2

See: https://github.com/ex-aws/ex_aws/blob/main/lib/ex_aws/operation/query.ex#L23