### PR TITLE
Supports Localstack topic creation

### DIFF
--- a/lib/ex_aws/sns.ex
+++ b/lib/ex_aws/sns.ex
@@ -577,7 +577,7 @@ defmodule ExAws.SNS do
     prefix = "Attributes.entry.#{index}."
 
     %{}
-    |> Map.put(prefix <> "name", format_param_key(name))
+    |> Map.put(prefix <> "key", format_param_key(name))
     |> Map.put(prefix <> "value", value)
   end
 

--- a/test/lib/sns_test.exs
+++ b/test/lib/sns_test.exs
@@ -16,7 +16,7 @@ defmodule ExAws.SNSTest do
     expected = %{
       "Action" => "CreateTopic",
       "Name" => "test_topic.fifo",
-      "Attributes.entry.1.name" => "FifoTopic",
+      "Attributes.entry.1.key" => "FifoTopic",
       "Attributes.entry.1.value" => true
     }
 
@@ -494,11 +494,11 @@ defmodule ExAws.SNSTest do
   test "#set_endpoint_attributes" do
     expected = %{
       "Action" => "SetEndpointAttributes",
-      "Attributes.entry.1.name" => "Token",
+      "Attributes.entry.1.key" => "Token",
       "Attributes.entry.1.value" => "1234",
-      "Attributes.entry.2.name" => "Enabled",
+      "Attributes.entry.2.key" => "Enabled",
       "Attributes.entry.2.value" => false,
-      "Attributes.entry.3.name" => "CustomUserData",
+      "Attributes.entry.3.key" => "CustomUserData",
       "Attributes.entry.3.value" => "blah",
       "EndpointArn" => "test-endpoint-arn"
     }


### PR DESCRIPTION
Updates the attribute building to support both AWS and Localstack.

While the `attribute.entry.<N>.name` format works for AWS, it does not work when using [Localstack](https://github.com/localstack/localstack) for local development. It requires the `attribute.entry.<N>.key` format which AWS seems to specify for both the [CreateTopic](https://docs.aws.amazon.com/sns/latest/api/API_CreateTopic.html#API_CreateTopic_RequestParameters) and [SetEndpointAttributes](https://docs.aws.amazon.com/sns/latest/api/API_SetEndpointAttributes.html#API_SetEndpointAttributes_RequestParameters) endpoints now as well.

These changes have been tested both on AWS and Localstack.